### PR TITLE
Fixed the Unicode logging issue in ooba_client.py

### DIFF
--- a/src/oobabot/ooba_client.py
+++ b/src/oobabot/ooba_client.py
@@ -262,7 +262,7 @@ class OobaClient(http_client.SerializedHttpClient):
                         text = incoming_data["text"]
                         if text != SentenceSplitter.END_OF_INPUT:
                             if self.log_all_the_things:
-                                print(text, end="", flush=True)
+                                print(text.encode('utf-8'), end="", flush=True)
 
                             yield text
 

--- a/src/oobabot/ooba_client.py
+++ b/src/oobabot/ooba_client.py
@@ -239,8 +239,8 @@ class OobaClient(http_client.SerializedHttpClient):
         ) as websocket:
             await websocket.send_json(request)
             if self.log_all_the_things:
-                print(f"Sent request:\n{json.dumps(request, indent=1)}")
-                print(f"Prompt:\n{request['prompt']}")
+                print(f"Sent request:\n{json.dumps(request, indent=1).encode('utf-8')}")
+                print(f"Prompt:\n{request['prompt'].encode('utf-8')}")
 
             async for msg in websocket:
                 # we expect a series of text messages in JSON encoding,


### PR DESCRIPTION
Related Issue:
https://github.com/chrisrude/oobabot/issues/65#issue-1806671339

Comment:
I still don't know if this was caused by some kind of a change in Oobabooga or the fact that my Windows 11 Pro got a huge developer preview update today. If the latter is the case, this issue would've been raised in the near future anyway. 

So in some sense, it showed itself earlier to me.
The big question is whether my hypothesis is correct. I don't have time to debug or trace the issue today but I've seen Microsoft screwing with codepages and Unicode encoding in the past too, causing problems for Python. 
