### PR TITLE
Unicode logging reliability fix ooba_client.py

### DIFF
--- a/src/oobabot/ooba_client.py
+++ b/src/oobabot/ooba_client.py
@@ -239,8 +239,13 @@ class OobaClient(http_client.SerializedHttpClient):
         ) as websocket:
             await websocket.send_json(request)
             if self.log_all_the_things:
-                print(f"Sent request:\n{json.dumps(request, indent=1).encode('utf-8')}")
-                print(f"Prompt:\n{str(request['prompt']).encode('utf-8')}")
+                try:
+                    print(f"Sent request:\n{json.dumps(request, indent=1)}")
+                    print(f"Prompt:\n{str(request['prompt'])}")
+                except UnicodeEncodeError:
+                    print(f"Sent request:\n{json.dumps(request, indent=1).encode('utf-8')}")
+                    print(f"Prompt:\n{str(request['prompt']).encode('utf-8')}")
+
 
             async for msg in websocket:
                 # we expect a series of text messages in JSON encoding,
@@ -262,7 +267,10 @@ class OobaClient(http_client.SerializedHttpClient):
                         text = incoming_data["text"]
                         if text != SentenceSplitter.END_OF_INPUT:
                             if self.log_all_the_things:
-                                print(text.encode("utf-8"), end="", flush=True)
+                                try:
+                                    print(text, end="", flush=True)
+                                except UnicodeEncodeError:
+                                    print(text.encode("utf-8"), end="", flush=True)
 
                             yield text
 


### PR DESCRIPTION
Looks like the oobabooga developer was the one who caused this [Unicode issue](https://github.com/chrisrude/oobabot/issues/65). 

Refactored the fix from the last pull request to enable it only when case it's actually needed. I don't trust developers who do everything on the main branch all the time not repeatedly causing this, so the bugfix is only applied when needed.

This commit ensures that this never happens either:
![WindowsTerminal_iMtGqTAi06](https://github.com/chrisrude/oobabot/assets/30772586/184cb88b-7b20-4dd8-ab91-4ae109556d57)

We want to see this:
![WindowsTerminal_Zp21zzsVaA](https://github.com/chrisrude/oobabot/assets/30772586/0faed95d-ebf3-44a4-b53a-33033a89ebe5)

Obviously, this isn't that bad compared to the situation from 2 days ago when the issue caused bot failures.